### PR TITLE
Add bilingual home page, footer, and placeholders

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Link, useLocation } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import Issues from './pages/Issues.jsx';
 import Events from './pages/Events.jsx';
@@ -8,32 +8,78 @@ import Endorsements from './pages/Endorsements.jsx';
 import Newsroom from './pages/Newsroom.jsx';
 import Contact from './pages/Contact.jsx';
 import Donate from './pages/Donate.jsx';
+import HomeEs from './pages/HomeEs.jsx';
+import IssuesEs from './pages/IssuesEs.jsx';
+import EventsEs from './pages/EventsEs.jsx';
+import VolunteerEs from './pages/VolunteerEs.jsx';
+import VoterInfoEs from './pages/VoterInfoEs.jsx';
+import EndorsementsEs from './pages/EndorsementsEs.jsx';
+import NewsroomEs from './pages/NewsroomEs.jsx';
+import ContactEs from './pages/ContactEs.jsx';
+import DonateEs from './pages/DonateEs.jsx';
+import Footer from './components/Footer.jsx';
+
+function Nav() {
+  const location = useLocation();
+  const isSpanish = location.pathname.startsWith('/es');
+  return (
+    <nav>
+      {isSpanish ? (
+        <>
+          <Link to="/es">Inicio</Link> |{' '}
+          <Link to="/es/issues">Propuestas</Link> |{' '}
+          <Link to="/es/events">Eventos</Link> |{' '}
+          <Link to="/es/volunteer">Voluntariado</Link> |{' '}
+          <Link to="/es/voter-info">Información para Votantes</Link> |{' '}
+          <Link to="/es/endorsements">Apoyos</Link> |{' '}
+          <Link to="/es/newsroom">Sala de Prensa</Link> |{' '}
+          <Link to="/es/contact">Contacto</Link> |{' '}
+          <Link to="/es/donate">Donar</Link> |{' '}
+          <Link to="/">English</Link>
+        </>
+      ) : (
+        <>
+          <Link to="/">Home</Link> |{' '}
+          <Link to="/issues">Issues</Link> |{' '}
+          <Link to="/events">Events</Link> |{' '}
+          <Link to="/volunteer">Volunteer</Link> |{' '}
+          <Link to="/voter-info">Voter Info</Link> |{' '}
+          <Link to="/endorsements">Endorsements</Link> |{' '}
+          <Link to="/newsroom">Newsroom</Link> |{' '}
+          <Link to="/contact">Contact</Link> |{' '}
+          <Link to="/donate">Donate</Link> |{' '}
+          <Link to="/es">Español</Link>
+        </>
+      )}
+    </nav>
+  );
+}
 
 export default function App() {
   return (
     <Router basename="/Bowling-Green/">
-      <nav>
-        <Link to="/">Home</Link> |{' '}
-        <Link to="/issues">Issues</Link> |{' '}
-        <Link to="/events">Events</Link> |{' '}
-        <Link to="/volunteer">Volunteer</Link> |{' '}
-        <Link to="/voter-info">Voter Info</Link> |{' '}
-        <Link to="/endorsements">Endorsements</Link> |{' '}
-        <Link to="/newsroom">Newsroom</Link> |{' '}
-        <Link to="/contact">Contact</Link> |{' '}
-        <Link to="/donate">Donate</Link>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/issues" element={<Issues />} />
-        <Route path="/events" element={<Events />} />
-        <Route path="/volunteer" element={<Volunteer />} />
-        <Route path="/voter-info" element={<VoterInfo />} />
-        <Route path="/endorsements" element={<Endorsements />} />
-        <Route path="/newsroom" element={<Newsroom />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route path="/donate" element={<Donate />} />
-      </Routes>
-    </Router>
+        <Nav />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/issues" element={<Issues />} />
+          <Route path="/events" element={<Events />} />
+          <Route path="/volunteer" element={<Volunteer />} />
+          <Route path="/voter-info" element={<VoterInfo />} />
+          <Route path="/endorsements" element={<Endorsements />} />
+          <Route path="/newsroom" element={<Newsroom />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/donate" element={<Donate />} />
+          <Route path="/es" element={<HomeEs />} />
+          <Route path="/es/issues" element={<IssuesEs />} />
+          <Route path="/es/events" element={<EventsEs />} />
+          <Route path="/es/volunteer" element={<VolunteerEs />} />
+          <Route path="/es/voter-info" element={<VoterInfoEs />} />
+          <Route path="/es/endorsements" element={<EndorsementsEs />} />
+          <Route path="/es/newsroom" element={<NewsroomEs />} />
+          <Route path="/es/contact" element={<ContactEs />} />
+          <Route path="/es/donate" element={<DonateEs />} />
+        </Routes>
+        <Footer />
+      </Router>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer>
+      <p>Paid for by Bowling Green Committee. Treasurer: Jane Doe.</p>
+    </footer>
+  );
+}

--- a/src/components/PlaceholderPage.jsx
+++ b/src/components/PlaceholderPage.jsx
@@ -1,0 +1,8 @@
+export default function PlaceholderPage({ title, message }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p className="placeholder-text">{message}</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './placeholder.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Contact() {
-  return <h1>Contact</h1>;
+  return <PlaceholderPage title="Contact" message="Content coming soon" />;
 }

--- a/src/pages/ContactEs.jsx
+++ b/src/pages/ContactEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function ContactEs() {
+  return <PlaceholderPage title="Contacto" message="Contenido próximamente" />;
+}

--- a/src/pages/Donate.jsx
+++ b/src/pages/Donate.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Donate() {
-  return <h1>Donate</h1>;
+  return <PlaceholderPage title="Donate" message="Content coming soon" />;
 }

--- a/src/pages/DonateEs.jsx
+++ b/src/pages/DonateEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function DonateEs() {
+  return <PlaceholderPage title="Donar" message="Contenido próximamente" />;
+}

--- a/src/pages/Endorsements.jsx
+++ b/src/pages/Endorsements.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Endorsements() {
-  return <h1>Endorsements</h1>;
+  return <PlaceholderPage title="Endorsements" message="Content coming soon" />;
 }

--- a/src/pages/EndorsementsEs.jsx
+++ b/src/pages/EndorsementsEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function EndorsementsEs() {
+  return <PlaceholderPage title="Apoyos" message="Contenido próximamente" />;
+}

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Events() {
-  return <h1>Events</h1>;
+  return <PlaceholderPage title="Events" message="Content coming soon" />;
 }

--- a/src/pages/EventsEs.jsx
+++ b/src/pages/EventsEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function EventsEs() {
+  return <PlaceholderPage title="Eventos" message="Contenido próximamente" />;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,19 @@
 export default function Home() {
-  return <h1>Home</h1>;
+  return (
+    <section>
+      <h1>Bowling Green Campaign</h1>
+      <p>
+        This site aims to inform and persuade voters in clear, plain language and provides quick access to platform
+        summaries, events, volunteer opportunities, donation links, and voter guidance. We offer equal access in English
+        and Spanish.
+      </p>
+      <ul>
+        <li>Explore issues and solutions.</li>
+        <li>See upcoming events and RSVP.</li>
+        <li>Join the volunteer team.</li>
+        <li>Get voter information.</li>
+        <li>Support the campaign with a donation.</li>
+      </ul>
+    </section>
+  );
 }

--- a/src/pages/HomeEs.jsx
+++ b/src/pages/HomeEs.jsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+
+export default function HomeEs() {
+  return (
+    <section>
+      <h1>Inicio</h1>
+      <p>
+        Nuestro sitio ayuda a informar y persuadir a los votantes con lenguaje claro. Ofrecemos acceso rápido a
+        resúmenes de propuestas, eventos, oportunidades de voluntariado, enlaces para donar e información para votantes.
+      </p>
+      <ul>
+        <li>Revisa las propuestas y soluciones.</li>
+        <li>Consulta eventos y confirma tu asistencia.</li>
+        <li>Únete como voluntariado.</li>
+        <li>Obtén información para votantes.</li>
+        <li>Apoya la campaña con una donación.</li>
+      </ul>
+      <p>
+        <Link to="/">English</Link>
+      </p>
+    </section>
+  );
+}

--- a/src/pages/Issues.jsx
+++ b/src/pages/Issues.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Issues() {
-  return <h1>Issues</h1>;
+  return <PlaceholderPage title="Issues" message="Content coming soon" />;
 }

--- a/src/pages/IssuesEs.jsx
+++ b/src/pages/IssuesEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function IssuesEs() {
+  return <PlaceholderPage title="Propuestas" message="Contenido próximamente" />;
+}

--- a/src/pages/Newsroom.jsx
+++ b/src/pages/Newsroom.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Newsroom() {
-  return <h1>Newsroom</h1>;
+  return <PlaceholderPage title="Newsroom" message="Content coming soon" />;
 }

--- a/src/pages/NewsroomEs.jsx
+++ b/src/pages/NewsroomEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function NewsroomEs() {
+  return <PlaceholderPage title="Sala de Prensa" message="Contenido próximamente" />;
+}

--- a/src/pages/Volunteer.jsx
+++ b/src/pages/Volunteer.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Volunteer() {
-  return <h1>Volunteer</h1>;
+  return <PlaceholderPage title="Volunteer" message="Content coming soon" />;
 }

--- a/src/pages/VolunteerEs.jsx
+++ b/src/pages/VolunteerEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function VolunteerEs() {
+  return <PlaceholderPage title="Voluntariado" message="Contenido próximamente" />;
+}

--- a/src/pages/VoterInfo.jsx
+++ b/src/pages/VoterInfo.jsx
@@ -1,3 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function VoterInfo() {
-  return <h1>Voter Info</h1>;
+  return <PlaceholderPage title="Voter Info" message="Content coming soon" />;
 }

--- a/src/pages/VoterInfoEs.jsx
+++ b/src/pages/VoterInfoEs.jsx
@@ -1,0 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
+export default function VoterInfoEs() {
+  return <PlaceholderPage title="Información para Votantes" message="Contenido próximamente" />;
+}

--- a/src/placeholder.css
+++ b/src/placeholder.css
@@ -1,0 +1,3 @@
+.placeholder-text {
+  color: #ff0000;
+}


### PR DESCRIPTION
## Summary
- add bright red placeholder stubs for all English pages and Spanish equivalents
- introduce language-aware navigation with routes to Spanish pages
- refactor placeholder pages into reusable component with shared CSS

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a134244832c89ecd95cbed3ea92