### PR TITLE
Add placeholder pages, navigation, and bilingual footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Link, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import Issues from './pages/Issues.jsx';
 import Events from './pages/Events.jsx';
@@ -18,68 +18,33 @@ import NewsroomEs from './pages/NewsroomEs.jsx';
 import ContactEs from './pages/ContactEs.jsx';
 import DonateEs from './pages/DonateEs.jsx';
 import Footer from './components/Footer.jsx';
-
-function Nav() {
-  const location = useLocation();
-  const isSpanish = location.pathname.startsWith('/es');
-  return (
-    <nav>
-      {isSpanish ? (
-        <>
-          <Link to="/es">Inicio</Link> |{' '}
-          <Link to="/es/issues">Propuestas</Link> |{' '}
-          <Link to="/es/events">Eventos</Link> |{' '}
-          <Link to="/es/volunteer">Voluntariado</Link> |{' '}
-          <Link to="/es/voter-info">Información para Votantes</Link> |{' '}
-          <Link to="/es/endorsements">Apoyos</Link> |{' '}
-          <Link to="/es/newsroom">Sala de Prensa</Link> |{' '}
-          <Link to="/es/contact">Contacto</Link> |{' '}
-          <Link to="/es/donate">Donar</Link> |{' '}
-          <Link to="/">English</Link>
-        </>
-      ) : (
-        <>
-          <Link to="/">Home</Link> |{' '}
-          <Link to="/issues">Issues</Link> |{' '}
-          <Link to="/events">Events</Link> |{' '}
-          <Link to="/volunteer">Volunteer</Link> |{' '}
-          <Link to="/voter-info">Voter Info</Link> |{' '}
-          <Link to="/endorsements">Endorsements</Link> |{' '}
-          <Link to="/newsroom">Newsroom</Link> |{' '}
-          <Link to="/contact">Contact</Link> |{' '}
-          <Link to="/donate">Donate</Link> |{' '}
-          <Link to="/es">Español</Link>
-        </>
-      )}
-    </nav>
-  );
-}
+import Nav from './components/Nav.jsx';
 
 export default function App() {
   return (
     <Router basename="/Bowling-Green/">
-        <Nav />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/issues" element={<Issues />} />
-          <Route path="/events" element={<Events />} />
-          <Route path="/volunteer" element={<Volunteer />} />
-          <Route path="/voter-info" element={<VoterInfo />} />
-          <Route path="/endorsements" element={<Endorsements />} />
-          <Route path="/newsroom" element={<Newsroom />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/donate" element={<Donate />} />
-          <Route path="/es" element={<HomeEs />} />
-          <Route path="/es/issues" element={<IssuesEs />} />
-          <Route path="/es/events" element={<EventsEs />} />
-          <Route path="/es/volunteer" element={<VolunteerEs />} />
-          <Route path="/es/voter-info" element={<VoterInfoEs />} />
-          <Route path="/es/endorsements" element={<EndorsementsEs />} />
-          <Route path="/es/newsroom" element={<NewsroomEs />} />
-          <Route path="/es/contact" element={<ContactEs />} />
-          <Route path="/es/donate" element={<DonateEs />} />
-        </Routes>
-        <Footer />
-      </Router>
+      <Nav />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/issues" element={<Issues />} />
+        <Route path="/events" element={<Events />} />
+        <Route path="/volunteer" element={<Volunteer />} />
+        <Route path="/voter-info" element={<VoterInfo />} />
+        <Route path="/endorsements" element={<Endorsements />} />
+        <Route path="/newsroom" element={<Newsroom />} />
+        <Route path="/contact" element={<Contact />} />
+        <Route path="/donate" element={<Donate />} />
+        <Route path="/es" element={<HomeEs />} />
+        <Route path="/es/issues" element={<IssuesEs />} />
+        <Route path="/es/events" element={<EventsEs />} />
+        <Route path="/es/volunteer" element={<VolunteerEs />} />
+        <Route path="/es/voter-info" element={<VoterInfoEs />} />
+        <Route path="/es/endorsements" element={<EndorsementsEs />} />
+        <Route path="/es/newsroom" element={<NewsroomEs />} />
+        <Route path="/es/contact" element={<ContactEs />} />
+        <Route path="/es/donate" element={<DonateEs />} />
+      </Routes>
+      <Footer />
+    </Router>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,15 @@
+import { useLocation } from 'react-router-dom';
+
 export default function Footer() {
+  const { pathname } = useLocation();
+  const isSpanish = pathname.startsWith('/es');
   return (
     <footer>
-      <p>Paid for by Bowling Green Committee. Treasurer: Jane Doe.</p>
+      <p>
+        {isSpanish
+          ? 'Pagado por el Comité de Bowling Green. Tesorera: Jane Doe.'
+          : 'Paid for by Bowling Green Committee. Treasurer: Jane Doe.'}
+      </p>
     </footer>
   );
 }

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,0 +1,37 @@
+import { Link, useLocation } from 'react-router-dom';
+
+const navItems = [
+  { path: '', en: 'Home', es: 'Inicio' },
+  { path: 'issues', en: 'Issues', es: 'Propuestas' },
+  { path: 'events', en: 'Events', es: 'Eventos' },
+  { path: 'volunteer', en: 'Volunteer', es: 'Voluntariado' },
+  { path: 'voter-info', en: 'Voter Info', es: 'Información para Votantes' },
+  { path: 'endorsements', en: 'Endorsements', es: 'Apoyos' },
+  { path: 'newsroom', en: 'Newsroom', es: 'Sala de Prensa' },
+  { path: 'contact', en: 'Contact', es: 'Contacto' },
+  { path: 'donate', en: 'Donate', es: 'Donar' },
+];
+
+export default function Nav() {
+  const { pathname } = useLocation();
+  const isSpanish = pathname.startsWith('/es');
+  const prefix = isSpanish ? '/es' : '';
+
+  return (
+    <nav>
+      <ul>
+        {navItems.map((item) => {
+          const to = item.path ? `${prefix}/${item.path}` : prefix || '/';
+          return (
+            <li key={item.path || 'home'}>
+              <Link to={to}>{isSpanish ? item.es : item.en}</Link>
+            </li>
+          );
+        })}
+        <li>
+          {isSpanish ? <Link to="/">English</Link> : <Link to="/es">Español</Link>}
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/PlaceholderPage.jsx
+++ b/src/components/PlaceholderPage.jsx
@@ -1,0 +1,8 @@
+export default function PlaceholderPage({ title, message }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p className="placeholder-text">{message}</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './placeholder.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Contact() {
-  return (
-    <div>
-      <h1>Contact</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Contact" message="Content coming soon" />;
 }

--- a/src/pages/ContactEs.jsx
+++ b/src/pages/ContactEs.jsx
@@ -1,9 +1,5 @@
-export default function ContactEs() {
-  return (
-    <div>
-      <h1>Contacto</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function ContactEs() {
+  return <PlaceholderPage title="Contacto" message="Contenido próximamente" />;
+}

--- a/src/pages/Donate.jsx
+++ b/src/pages/Donate.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Donate() {
-  return (
-    <div>
-      <h1>Donate</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Donate" message="Content coming soon" />;
 }

--- a/src/pages/DonateEs.jsx
+++ b/src/pages/DonateEs.jsx
@@ -1,9 +1,5 @@
-export default function DonateEs() {
-  return (
-    <div>
-      <h1>Donar</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function DonateEs() {
+  return <PlaceholderPage title="Donar" message="Contenido próximamente" />;
+}

--- a/src/pages/Endorsements.jsx
+++ b/src/pages/Endorsements.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Endorsements() {
-  return (
-    <div>
-      <h1>Endorsements</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Endorsements" message="Content coming soon" />;
 }

--- a/src/pages/EndorsementsEs.jsx
+++ b/src/pages/EndorsementsEs.jsx
@@ -1,9 +1,5 @@
-export default function EndorsementsEs() {
-  return (
-    <div>
-      <h1>Apoyos</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function EndorsementsEs() {
+  return <PlaceholderPage title="Apoyos" message="Contenido próximamente" />;
+}

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Events() {
-  return (
-    <div>
-      <h1>Events</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Events" message="Content coming soon" />;
 }

--- a/src/pages/EventsEs.jsx
+++ b/src/pages/EventsEs.jsx
@@ -1,9 +1,5 @@
-export default function EventsEs() {
-  return (
-    <div>
-      <h1>Eventos</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function EventsEs() {
+  return <PlaceholderPage title="Eventos" message="Contenido próximamente" />;
+}

--- a/src/pages/Issues.jsx
+++ b/src/pages/Issues.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Issues() {
-  return (
-    <div>
-      <h1>Issues</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Issues" message="Content coming soon" />;
 }

--- a/src/pages/IssuesEs.jsx
+++ b/src/pages/IssuesEs.jsx
@@ -1,9 +1,5 @@
-export default function IssuesEs() {
-  return (
-    <div>
-      <h1>Propuestas</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function IssuesEs() {
+  return <PlaceholderPage title="Propuestas" message="Contenido próximamente" />;
+}

--- a/src/pages/Newsroom.jsx
+++ b/src/pages/Newsroom.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Newsroom() {
-  return (
-    <div>
-      <h1>Newsroom</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Newsroom" message="Content coming soon" />;
 }

--- a/src/pages/NewsroomEs.jsx
+++ b/src/pages/NewsroomEs.jsx
@@ -1,9 +1,5 @@
-export default function NewsroomEs() {
-  return (
-    <div>
-      <h1>Sala de Prensa</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function NewsroomEs() {
+  return <PlaceholderPage title="Sala de Prensa" message="Contenido próximamente" />;
+}

--- a/src/pages/Volunteer.jsx
+++ b/src/pages/Volunteer.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function Volunteer() {
-  return (
-    <div>
-      <h1>Volunteer</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Volunteer" message="Content coming soon" />;
 }

--- a/src/pages/VolunteerEs.jsx
+++ b/src/pages/VolunteerEs.jsx
@@ -1,9 +1,5 @@
-export default function VolunteerEs() {
-  return (
-    <div>
-      <h1>Voluntariado</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function VolunteerEs() {
+  return <PlaceholderPage title="Voluntariado" message="Contenido próximamente" />;
+}

--- a/src/pages/VoterInfo.jsx
+++ b/src/pages/VoterInfo.jsx
@@ -1,8 +1,5 @@
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
+
 export default function VoterInfo() {
-  return (
-    <div>
-      <h1>Voter Info</h1>
-      <p style={{ color: '#ff0000' }}>Content coming soon</p>
-    </div>
-  );
+  return <PlaceholderPage title="Voter Info" message="Content coming soon" />;
 }

--- a/src/pages/VoterInfoEs.jsx
+++ b/src/pages/VoterInfoEs.jsx
@@ -1,9 +1,5 @@
-export default function VoterInfoEs() {
-  return (
-    <div>
-      <h1>Información para Votantes</h1>
-      <p style={{ color: '#ff0000' }}>Contenido próximamente</p>
-    </div>
-  );
-}
+import PlaceholderPage from '../components/PlaceholderPage.jsx';
 
+export default function VoterInfoEs() {
+  return <PlaceholderPage title="Información para Votantes" message="Contenido próximamente" />;
+}

--- a/src/placeholder.css
+++ b/src/placeholder.css
@@ -1,0 +1,3 @@
+.placeholder-text {
+  color: #ff0000;
+}


### PR DESCRIPTION
## Summary
- Introduce reusable navigation component that supports English and Spanish routes and language toggle
- Add bilingual footer message that switches based on current language
- Provide placeholder pages with shared styling for sections under construction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be3d790ac8832cb00b0d6068587cdd